### PR TITLE
Add top-level CSS module

### DIFF
--- a/src/CSS.purs
+++ b/src/CSS.purs
@@ -1,0 +1,35 @@
+module CSS
+    ( module X
+    , module CSS.Media
+    ) where
+
+-----------------------------------------
+-- Modules that can be fully exported. --
+-----------------------------------------
+
+import CSS.Animation as X
+import CSS.Background as X
+import CSS.Border as X
+import CSS.Color as X
+import CSS.Display as X
+import CSS.Elements as X
+import CSS.FontFace as X
+import CSS.Font as X
+import CSS.Geometry as X
+import CSS.Gradient as X
+import CSS.Property as X
+import CSS.Pseudo as X
+import CSS.Selector as X
+import CSS.Size as X
+import CSS.String as X
+import CSS.Stylesheet as X
+import CSS.Text as X
+import CSS.Time as X
+import CSS.Transform as X
+import CSS.Transition as X
+
+----------------------------------------------
+-- Modules that have conflicting functions. --
+----------------------------------------------
+
+import CSS.Media hiding (maxWidth)

--- a/src/CSS.purs
+++ b/src/CSS.purs
@@ -1,11 +1,4 @@
-module CSS
-    ( module X
-    , module CSS.Media
-    ) where
-
------------------------------------------
--- Modules that can be fully exported. --
------------------------------------------
+module CSS (module X) where
 
 import CSS.Animation as X
 import CSS.Background as X
@@ -27,9 +20,3 @@ import CSS.Text as X
 import CSS.Time as X
 import CSS.Transform as X
 import CSS.Transition as X
-
-----------------------------------------------
--- Modules that have conflicting functions. --
-----------------------------------------------
-
-import CSS.Media hiding (maxWidth)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,7 +15,6 @@ import CSS.Size
 import CSS.String
 import CSS.Stylesheet
 import Data.Maybe
-import Data.These
 
 example1 :: Rendered
 example1 = render do


### PR DESCRIPTION
This pull-request adds a top-level `CSS` module that exports all the the `CSS.*` sub-modules, except for `CSS.Render`.  It also removes an uneeded import from the testing file.

One small problem is that `maxWidth` is exported from both `CSS.Geometry` and `CSS.Media`.  I hid the `maxWidth` from `CSS.Media`.  I made this decision pretty much arbitrarily, so if you think something else should be done, let me know.

Also, please let me know if there are modules other than `CSS.Render` that shouldn't be exported.

