### PR TITLE
added prefixed animation and keyframes

### DIFF
--- a/src/CSS/Animation.purs
+++ b/src/CSS/Animation.purs
@@ -3,6 +3,7 @@ module CSS.Animation where
 import Prelude
 
 import Data.Tuple.Nested (tuple7)
+import Data.Foldable (for_)
 
 import CSS.Property
 import CSS.String
@@ -50,7 +51,18 @@ backwards :: FillMode
 backwards = FillMode $ fromString "backwards"
 
 animation :: AnimationName -> Time -> TimingFunction -> Time -> IterationCount -> AnimationDirection -> FillMode -> CSS
-animation p de f du i di fm = key (fromString "-webkit-animation") (tuple7 p de f du i di fm)
+animation p de f du i di fm = do
+  for_ animationKeys \k ->
+    key (fromString k) (tuple7 p de f du i di fm)
+  where
+  animationKeys =
+    [ "animation"
+    , "-webkit-animation"
+    , "-moz-animation"
+    , "-o-animation"
+    ]
+
+
 
 newtype AnimationName = AnimationName Value
 

--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -50,7 +50,19 @@ render :: forall a. StyleM a -> Rendered
 render = rules [] <<< runS
 
 kframe :: Keyframes -> Rendered
-kframe (Keyframes ident xs) = Just <<< That <<< Sheet $ "@-webkit-keyframes " <> ident <> " { " <> intercalate " " (uncurry frame <$> xs) <> " }\n"
+kframe (Keyframes ident xs) =
+  Just $ That $ Sheet $ allKeywordsWithContent
+  where
+  renderContent =
+    " " <> ident <> " { " <> intercalate " " (uncurry frame <$> xs) <> " }\n"
+  keywords =
+    [ "@keyframes"
+    , "@-webkit-keyframes"
+    , "@-moz-keyframes"
+    , "@-o-keyframes"
+    ]
+  allKeywordsWithContent =
+    mconcat $ map (_ <> renderContent) keywords
 
 frame :: Number -> Array Rule -> String
 frame p rs = show p <> "% " <> "{ " <> x <> " }"


### PR DESCRIPTION
@beckyconning could you please take a look? 

This makes `animation` and `keyframes` funcs rendering unprefixed and prefixed version. This doesn't change API and I suggest this should a patch version. 