### PR TITLE
Nested node rendering fixes

### DIFF
--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -1,7 +1,7 @@
 module CSS.Render where
 
 import Prelude
-import Data.Array ((:), drop, sort, uncons, mapMaybe)
+import Data.Array (null, (:), drop, sort, uncons, mapMaybe)
 import Data.Either (Either(..), either)
 import Data.Foldable (fold, foldMap, intercalate, mconcat)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
@@ -96,7 +96,10 @@ rules sel rs = topRules <> importRules <> keyframeRules <> faceRules <> nestedSh
         faces    _              = Nothing
         imports  (Import i    ) = Just i
         imports  _              = Nothing
-        topRules      = rule' sel (mapMaybe property rs)
+        topRules      = if not null rs'
+                          then rule' sel rs'
+                          else Nothing
+          where rs' = mapMaybe property rs
         nestedSheets  = fold $ uncurry nestedRules <$> mapMaybe nested rs
         nestedRules a = rules (a : sel)
         queryRules    = foldMap (uncurry $ flip query' sel) $ mapMaybe queries rs

--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -1,6 +1,8 @@
 module CSS.Render where
 
 import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (log, CONSOLE)
 import Data.Array (null, (:), drop, sort, uncons, mapMaybe)
 import Data.Either (Either(..), either)
 import Data.Foldable (fold, foldMap, intercalate, mconcat)
@@ -47,6 +49,14 @@ renderedSheet = (>>= (map getSheet <<< theseRight))
 
 render :: forall a. StyleM a -> Rendered
 render = rules [] <<< runS
+
+putInline :: forall e. CSS -> Eff (console :: CONSOLE | e) Unit
+putInline s =
+  log <<< fromMaybe "" <<< renderedInline <<< render $ s
+
+putStyleSheet :: forall e. CSS -> Eff (console :: CONSOLE | e) Unit
+putStyleSheet s =
+  log <<< fromMaybe "" <<< renderedSheet <<< render $ s
 
 kframe :: Keyframes -> Rendered
 kframe (Keyframes ident xs) =

--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -1,10 +1,9 @@
 module CSS.Render where
 
 import Prelude
-
 import Data.Array ((:), drop, sort, uncons, mapMaybe)
 import Data.Either (Either(..), either)
-import Data.Foldable (foldMap, intercalate, mconcat)
+import Data.Foldable (fold, foldMap, intercalate, mconcat)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Monoid (Monoid, mempty)
 import Data.NonEmpty (NonEmpty(..), (:|), foldl1, oneOf)
@@ -98,7 +97,7 @@ rules sel rs = topRules <> importRules <> keyframeRules <> faceRules <> nestedSh
         imports  (Import i    ) = Just i
         imports  _              = Nothing
         topRules      = rule' sel (mapMaybe property rs)
-        nestedSheets  = foldMap (<> (Just <<< That $ Sheet "\n")) $ uncurry nestedRules <$> mapMaybe nested rs
+        nestedSheets  = fold $ uncurry nestedRules <$> mapMaybe nested rs
         nestedRules a = rules (a : sel)
         queryRules    = foldMap (uncurry $ flip query' sel) $ mapMaybe queries rs
         keyframeRules = foldMap kframe $ mapMaybe kframes rs
@@ -112,7 +111,7 @@ rule' :: forall a. Array App -> Array (Tuple (Key a) Value) -> Rendered
 rule' sel props = maybe q o $ nel sel
   where p = props >>= collect
         q = (This <<< Inline <<< properties <<< oneOf) <$> nel p
-        o sel' = Just <<< That <<< Sheet $ intercalate " " [selector (merger sel'), "{", properties p, "}"]
+        o sel' = Just <<< That <<< Sheet $ intercalate " " [selector (merger sel'), "{", properties p, "}\n"]
 
 selector :: Selector -> String
 selector = intercalate ", " <<< selector'

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -42,6 +42,12 @@ example5 = render do
   boxSizing contentBox
   boxSizing borderBox
 
+nestedNodes :: Rendered
+nestedNodes = render do
+  fromString "#parent" ? do
+    display block
+    fromString "#child" ? display block
+
 assertEqual :: forall a. (Eq a, Show a) => a -> a -> Eff (err :: EXCEPTION) Unit
 assertEqual x y = unless (x == y) <<< throwException <<< error $ "Assertion failed: " <> show x <> " /= " <> show y
 
@@ -58,3 +64,6 @@ main = do
   renderedSheet example4 `assertEqual` Just "body { color: hsl(240.0, 100.0%, 50.0%) }\n#world { display: block }\n"
 
   renderedInline example5 `assertEqual` Just "box-sizing: content-box; box-sizing: border-box"
+
+  renderedSheet nestedNodes `assertEqual` Just "#parent { display: block }\n#parent #child { display: block }\n"
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -48,6 +48,11 @@ nestedNodes = render do
     display block
     fromString "#child" ? display block
 
+nestedNodesWithEmptyParent :: Rendered
+nestedNodesWithEmptyParent = render do
+  fromString "#parent" ? do
+    fromString "#child" ? display block
+
 assertEqual :: forall a. (Eq a, Show a) => a -> a -> Eff (err :: EXCEPTION) Unit
 assertEqual x y = unless (x == y) <<< throwException <<< error $ "Assertion failed: " <> show x <> " /= " <> show y
 
@@ -66,4 +71,6 @@ main = do
   renderedInline example5 `assertEqual` Just "box-sizing: content-box; box-sizing: border-box"
 
   renderedSheet nestedNodes `assertEqual` Just "#parent { display: block }\n#parent #child { display: block }\n"
+
+  renderedSheet nestedNodesWithEmptyParent `assertEqual` Just "#parent #child { display: block }\n"
 


### PR DESCRIPTION
I've fixed two issues:
 
   * generated stylesheet for nested nodes was incorrect - there was newline character missing after parent properties block),

   * I've added added small improvement regarding nested nodes rendering - empty rules blocks are skipped from output

I've added two test case for every change.