### PR TITLE
Cover more css properties

### DIFF
--- a/src/CSS/Common.purs
+++ b/src/CSS/Common.purs
@@ -21,8 +21,10 @@ class Auto     a where auto     :: a
 class Baseline a where baseline :: a
 class Center   a where center   :: a
 class Inherit  a where inherit  :: a
+class Left     a where left     :: a
 class None     a where none     :: a
 class Normal   a where normal   :: a
+class Right    a where right    :: a
 class Visible  a where visible  :: a
 class Hidden   a where hidden   :: a
 class Initial  a where initial  :: a
@@ -39,8 +41,10 @@ instance autoValue     :: Auto     Value where auto     = fromString "auto"
 instance baselineValue :: Baseline Value where baseline = fromString "baseline"
 instance centerValue   :: Center   Value where center   = fromString "center"
 instance inheritValue  :: Inherit  Value where inherit  = fromString "inherit"
+instance leftValue     :: Left     Value where left     = fromString "left"
 instance normalValue   :: Normal   Value where normal   = fromString "normal"
 instance noneValue     :: None     Value where none     = fromString "none"
+instance rightValue    :: Right    Value where right    = fromString "right"
 instance visibleValue  :: Visible  Value where visible  = fromString "visible"
 instance hiddenValue   :: Hidden   Value where hidden   = fromString "hidden"
 instance otherValue    :: Other    Value where other    = id

--- a/src/CSS/Display.purs
+++ b/src/CSS/Display.purs
@@ -181,3 +181,6 @@ instance rightClear :: Right Clear where
 
 both :: Clear
 both = Clear $ fromString "both"
+
+clear :: Clear -> CSS
+clear = key $ fromString "clear"

--- a/src/CSS/Display.purs
+++ b/src/CSS/Display.purs
@@ -1,12 +1,12 @@
 module CSS.Display where
 
 import Prelude
-
-import Data.Generic (class Generic)
-
+import CSS.Common (class Right, right, left, class Left, class None, class Inherit, class Initial, none, inherit, initial)
 import CSS.Property (class Val, Value)
+import CSS.Size (Size)
 import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)
+import Data.Generic (class Generic)
 
 newtype Position = Position Value
 
@@ -32,6 +32,18 @@ fixed = Position $ fromString "fixed"
 relative :: Position
 relative = Position $ fromString "relative"
 
+positionBottom :: forall a. Size a -> CSS
+positionBottom v = key (fromString "bottom") $ v
+
+positionLeft :: forall a. Size a -> CSS
+positionLeft v = key (fromString "left") $ v
+
+positionRight :: forall a. Size a -> CSS
+positionRight v = key (fromString "right") $ v
+
+positionTop :: forall a. Size a -> CSS
+positionTop v = key (fromString "top") $ v
+
 newtype Display = Display Value
 
 derive instance eqDisplay :: Eq Display
@@ -40,6 +52,21 @@ derive instance genericDisplay :: Generic Display
 
 instance valDisplay :: Val Display where
   value (Display v) = v
+
+instance initialDisplay :: Initial Display where
+  initial = Display initial
+
+instance inheritDisplay :: Inherit Display where
+  inherit = Display inherit
+
+instance noneDisplay :: None Display where
+  none = Display none
+
+displayNone :: Display
+displayNone = none
+
+displayInherit :: Display
+displayInherit = inherit
 
 inline :: Display
 inline = Display $ fromString "inline"
@@ -86,12 +113,6 @@ tableCell = Display $ fromString "table-cell"
 tableCaption :: Display
 tableCaption = Display $ fromString "table-caption"
 
-displayNone :: Display
-displayNone = Display $ fromString "none"
-
-displayInherit :: Display
-displayInherit = Display $ fromString "inherit"
-
 flex :: Display
 flex = Display $ fromString "flex"
 
@@ -106,3 +127,57 @@ inlineGrid = Display $ fromString "inline-grid"
 
 display :: Display -> CSS
 display = key $ fromString "display"
+
+newtype Float = Float Value
+
+derive instance eqFloat :: Eq Float
+derive instance ordFloat :: Ord Float
+derive instance genericFloat :: Generic Float
+
+instance valFloat :: Val Float where
+  value (Float v) = v
+
+instance initialFloat :: Initial Float where
+  initial = Float initial
+
+instance inheritFloat :: Inherit Float where
+  inherit = Float inherit
+
+instance noneFloat :: None Float where
+  none = Float none
+
+instance leftFloat :: Left Float where
+  left = Float left
+
+instance rightFloat :: Right Float where
+  right = Float right
+
+float :: Float -> CSS
+float = key $ fromString "float"
+
+newtype Clear = Clear Value
+
+derive instance eqClear :: Eq Clear
+derive instance ordClear :: Ord Clear
+derive instance genericClear :: Generic Clear
+
+instance valClear :: Val Clear where
+  value (Clear v) = v
+
+instance initialClear :: Initial Clear where
+  initial = Clear initial
+
+instance inheritClear :: Inherit Clear where
+  inherit = Clear inherit
+
+instance noneClear :: None Clear where
+  none = Clear none
+
+instance leftClear :: Left Clear where
+  left = Clear left
+
+instance rightClear :: Right Clear where
+  right = Clear right
+
+both :: Clear
+both = Clear $ fromString "both"

--- a/src/CSS/List.purs
+++ b/src/CSS/List.purs
@@ -1,0 +1,117 @@
+module CSS.List where
+
+import Prelude
+import CSS.Common (class Inherit, inherit, class Initial, class None, initial, none)
+import CSS.Property (class Val, Value, value)
+import CSS.String (fromString)
+import CSS.Stylesheet (key, CSS)
+import Data.Generic (class Generic)
+
+newtype ListStyleType = ListStyleType Value
+
+derive instance eqPosition :: Eq ListStyleType
+derive instance ordPosition :: Ord ListStyleType
+derive instance genericPosition :: Generic ListStyleType
+
+instance valListStyleType :: Val ListStyleType where
+  value (ListStyleType v) = v
+
+instance initialListStyleType :: Initial ListStyleType where
+  initial = ListStyleType initial
+
+instance inheritListStyleType :: Inherit ListStyleType where
+  inherit = ListStyleType inherit
+
+instance noneListStyleType :: None ListStyleType where
+  none = ListStyleType none
+
+listStyleType :: ListStyleType -> CSS
+listStyleType = key $ fromString "list-style-type"
+
+disc :: ListStyleType
+disc = ListStyleType $ fromString "disc"
+armenian :: ListStyleType
+armenian = ListStyleType $ fromString "armenian"
+circleListStyle :: ListStyleType
+circleListStyle = ListStyleType $ fromString "circle"
+cjkIdeographic :: ListStyleType
+cjkIdeographic = ListStyleType $ fromString "cjk-ideographic"
+decimal :: ListStyleType
+decimal = ListStyleType $ fromString "decimal"
+decimalLeadingZero :: ListStyleType
+decimalLeadingZero = ListStyleType $ fromString "decimal-leading-zero"
+georgian :: ListStyleType
+georgian = ListStyleType $ fromString "georgian"
+hebrew :: ListStyleType
+hebrew = ListStyleType $ fromString "hebrew"
+hiragana :: ListStyleType
+hiragana = ListStyleType $ fromString "hiragana"
+hiraganaIroha :: ListStyleType
+hiraganaIroha = ListStyleType $ fromString "hiragana-iroha"
+katakana :: ListStyleType
+katakana = ListStyleType $ fromString "katakana"
+katakanaIroha :: ListStyleType
+katakanaIroha = ListStyleType $ fromString "katakana-iroha"
+lowerAlpha :: ListStyleType
+lowerAlpha = ListStyleType $ fromString "lower-alpha"
+lowerGreek :: ListStyleType
+lowerGreek = ListStyleType $ fromString "lower-greek"
+lowerLatin :: ListStyleType
+lowerLatin = ListStyleType $ fromString "lower-latin"
+lowerRoman :: ListStyleType
+lowerRoman = ListStyleType $ fromString "lower-roman"
+square :: ListStyleType
+square = ListStyleType $ fromString "square"
+upperAlpha :: ListStyleType
+upperAlpha = ListStyleType $ fromString "upper-alpha"
+upperLatin :: ListStyleType
+upperLatin = ListStyleType $ fromString "upper-latin"
+upperRoman :: ListStyleType
+upperRoman = ListStyleType $ fromString "upper-roman"
+
+newtype ListStylePosition = ListStylePosition Value
+
+derive instance eqListStylePosition :: Eq ListStylePosition
+derive instance ordListStylePosition :: Ord ListStylePosition
+derive instance genericListStylePosition :: Generic ListStylePosition
+
+instance valListStylePosition :: Val ListStylePosition where
+  value (ListStylePosition v) = v
+
+instance initialListStylePosition :: Initial ListStylePosition where
+  initial = ListStylePosition initial
+
+instance inheritListStylePosition :: Inherit ListStylePosition where
+  inherit = ListStylePosition inherit
+
+listStylePosition :: ListStylePosition -> CSS
+listStylePosition = key $ fromString "list-style-position"
+
+inside :: ListStylePosition
+inside  = ListStylePosition (value "inside")
+outside :: ListStylePosition
+outside = ListStylePosition (value "outside")
+
+newtype ListStyleImage = ListStyleImage Value
+
+derive instance eqListStyleImage :: Eq ListStyleImage
+derive instance ordListStyleImage :: Ord ListStyleImage
+derive instance genericListStyleImage :: Generic ListStyleImage
+
+instance valListStyleImage :: Val ListStyleImage where
+  value (ListStyleImage v) = v
+
+instance initialListStyleImage :: Initial ListStyleImage where
+  initial = ListStyleImage initial
+
+instance inheritListStyleImage :: Inherit ListStyleImage where
+  inherit = ListStyleImage inherit
+
+instance noneListStyleImage :: None ListStyleImage where
+  none = ListStyleImage none
+
+listStyleImage :: ListStyleImage -> CSS
+listStyleImage = key $ fromString "list-style-image"
+
+imageUrl :: String -> ListStyleImage
+imageUrl u = ListStyleImage $ fromString ("url(" <> u <> ")")

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,10 +1,11 @@
 module Test.Main where
 
 import Prelude
-
+import CSS (Rendered, Path(..), Predicate(..), Refinement(..), Selector(..), renderedSheet, renderedInline, fromString, selector, block, display, render, borderBox, boxSizing, contentBox, blue, color, body, px, dashed, border, inlineBlock, red, (?))
+import CSS.Common (none)
+import CSS.List (inside, square, listStyleImage, listStylePosition, listStyleType)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (EXCEPTION, error, throwException)
-import CSS (Rendered, Path(..), Predicate(..), Refinement(..), Selector(..), renderedSheet, renderedInline, fromString, selector, block, display, render, borderBox, boxSizing, contentBox, blue, color, body, px, dashed, border, inlineBlock, red, (?))
 import Data.Maybe (Maybe(..))
 
 example1 :: Rendered
@@ -31,6 +32,12 @@ example5 :: Rendered
 example5 = render do
   boxSizing contentBox
   boxSizing borderBox
+
+listStyle :: Rendered
+listStyle = render do
+  listStyleType square
+  listStylePosition inside
+  listStyleImage none
 
 nestedNodes :: Rendered
 nestedNodes = render do
@@ -59,6 +66,8 @@ main = do
   renderedSheet example4 `assertEqual` Just "body { color: hsl(240.0, 100.0%, 50.0%) }\n#world { display: block }\n"
 
   renderedInline example5 `assertEqual` Just "box-sizing: content-box; box-sizing: border-box"
+
+  renderedInline listStyle `assertEqual` Just "list-style-type: square; list-style-position: inside; list-style-image: none"
 
   renderedSheet nestedNodes `assertEqual` Just "#parent { display: block }\n#parent #child { display: block }\n"
 


### PR DESCRIPTION
I'm not sure if proposed `CSS.Common.Left` and `CSS.Common.Right` typeclasses should be included  - in general I'm not a big fun of such typeclasses usage, but I've found that this library is written in such a style.

Additionally `Left` and `Right` are quite confusing names for typeclasses in regards to `Either` data type.
I can change the names to `LeftValue` and `RightValue` or remove them and introduce appropriate values as `floatLeft`, `clearLeft`, `textAlignLeft` etc.

What do you think?
