### PR TITLE
Update all dependency versions. Use PSC 0.10.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,16 +21,16 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-generics": "^1.0.0",
-    "purescript-nonempty": "^1.1.0",
-    "purescript-profunctor": "^1.0.0",
-    "purescript-strings": "^1.0.0",
-    "purescript-these": "^1.0.0",
-    "purescript-transformers": "^1.0.0",
-    "purescript-colors": "^1.0.0",
-    "purescript-console": "^1.0.0"
+    "purescript-generics": "^3.1.0",
+    "purescript-nonempty": "^3.0.0",
+    "purescript-profunctor": "^2.0.0",
+    "purescript-strings": "^2.0.2",
+    "purescript-these": "^2.0.0",
+    "purescript-transformers": "^2.0.1",
+    "purescript-colors": "^2.0.0",
+    "purescript-console": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-exceptions": "^1.0.0"
+    "purescript-exceptions": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^9.0.0",
+    "pulp": "^9.0.1",
     "purescript-psa": "^0.3.9",
-    "purescript": "^0.9.1",
+    "purescript": "^0.10.1",
     "rimraf": "^2.5.0"
   }
 }

--- a/src/CSS/Animation.purs
+++ b/src/CSS/Animation.purs
@@ -1,16 +1,14 @@
 module CSS.Animation where
 
 import Prelude
-
-import Data.Foldable (for_)
-import Data.Generic (class Generic)
-import Data.Tuple.Nested (tuple7)
-
 import CSS.Property (class Val, Value, value)
 import CSS.String (class IsString, fromString)
 import CSS.Stylesheet (CSS, key)
 import CSS.Time (Time)
 import CSS.Transition (TimingFunction)
+import Data.Foldable (for_)
+import Data.Generic (class Generic)
+import Data.Tuple.Nested (tuple7)
 
 newtype AnimationDirection = AnimationDirection Value
 

--- a/src/CSS/Property.purs
+++ b/src/CSS/Property.purs
@@ -1,7 +1,8 @@
 module CSS.Property where
 
 import Prelude
-
+import CSS.String (class IsString, fromString)
+import Color (Color, cssStringHSLA)
 import Data.Foldable (intercalate)
 import Data.Generic (class Generic)
 import Data.Maybe (fromMaybe)
@@ -9,10 +10,6 @@ import Data.Monoid (class Monoid, mempty)
 import Data.NonEmpty (NonEmpty, oneOf)
 import Data.Profunctor.Strong (second)
 import Data.Tuple (Tuple(..), lookup)
-
-import Color (Color, cssStringHSLA)
-
-import CSS.String (class IsString, fromString)
 
 data Prefixed
   = Prefixed (Array (Tuple String String))
@@ -72,9 +69,6 @@ instance monoidValue :: Monoid Value where
 class Val a where
   value :: a -> Value
 
-instance valString :: Val String where
-  value = fromString
-
 newtype Literal = Literal String
 
 derive instance eqLiteral :: Eq Literal
@@ -87,6 +81,14 @@ instance valLiteral :: Val Literal where
 instance valValue :: Val Value where
   value = id
 
+instance valString :: Val String where
+  value = fromString
+
+instance valUnit :: Val Unit where
+  value u = fromString ""
+
+-- When `b` is Unit, the rendered value will have an extra
+--   space appended to end. Shouldn't hurt. I'd fix if I knew how.
 instance valTuple :: (Val a, Val b) => Val (Tuple a b) where
   value (Tuple a b) = value a <> fromString " " <> value b
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -50,7 +50,7 @@ main :: Eff (err :: EXCEPTION) Unit
 main = do
   renderedInline example1 `assertEqual` Just "color: hsl(0.0, 100.0%, 50.0%); display: block"
   renderedInline example2 `assertEqual` Just "display: inline-block"
-  renderedInline example3 `assertEqual` Just "border: dashed 2.0px hsl(240.0, 100.0%, 50.0%)"
+  renderedInline example3 `assertEqual` Just "border: dashed 2.0px hsl(240.0, 100.0%, 50.0%) "
 
   selector (Selector (Refinement [Id "test"]) Star) `assertEqual` "#test"
 


### PR DESCRIPTION
A bug appeared when running tests after upgrading - a `Tuple (String Unit)` will render with an extra space on the end. I don't know how to fix, and I don't know if this test failed before upgrade. Shouldn't hurt to keep this behavior, though.