### PR TITLE
update ps-colors version range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "purescript-strings": "^3.0.0",
     "purescript-these": "^3.0.0",
     "purescript-transformers": "^3.2.0",
-    "purescript-colors": "^3.0.0",
+    "purescript-colors": "3.x - 4.x",
     "purescript-console": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes in new version are not that braking only internal representation has changed for Color and ColorScale which do not affect ps-css. so we can safely use wider range of ps-colors.

This is the change tigerring new version https://github.com/sharkdp/purescript-colors/pull/31