### PR TITLE
Add unitless size

### DIFF
--- a/src/CSS/Size.purs
+++ b/src/CSS/Size.purs
@@ -23,36 +23,51 @@ instance autoSize :: Auto (Size a) where
 data Abs
 data Rel
 
+-- | Zero size.
 nil :: forall a. Size a
 nil = Size $ fromString "0"
 
+-- | Unitless size (as recommended for line-height).
+unitless ∷ forall a. Number → Size a
+unitless = Size <<< value
+
+-- | Size in pixels.
 px :: Number -> Size Abs
 px i = Size (value i <> fromString "px")
 
+-- | Size in points (1pt = 1/72 of 1in).
 pt :: Number -> Size Abs
 pt i = Size (value i <> fromString "pt")
 
+-- | Size in em's.
 em :: Number -> Size Abs
 em i = Size (value i <> fromString "em")
 
+-- | Size in ex'es (x-height of the first avaliable font).
 ex :: Number -> Size Abs
 ex i = Size (value i <> fromString "ex")
 
+-- | SimpleSize in percents.
 pct :: Number -> Size Rel
 pct i = Size (value i <> fromString "%")
 
+-- | Size in rem's.
 rem :: Number -> Size Rel
 rem i = Size (value i <> fromString "rem")
 
+-- | Size in vw's (1vw = 1% of viewport width).
 vw :: Number -> Size Rel
 vw i = Size (value i <> fromString "vw")
 
+-- | Size in vh's (1vh = 1% of viewport height).
 vh :: Number -> Size Rel
 vh i = Size (value i <> fromString "vh")
 
+-- | Size in vmin's (the smaller of vw or vh).
 vmin :: Number -> Size Rel
 vmin i = Size (value i <> fromString "vmin")
 
+-- | Size in vmax's (the larger of vw or vh).
 vmax :: Number -> Size Rel
 vmax i = Size (value i <> fromString "vmax")
 
@@ -70,8 +85,10 @@ derive instance ordAngle :: Ord a => Ord (Angle a)
 instance valAngle :: Val (Angle a) where
   value (Angle v) = v
 
+-- | Angle in degrees.
 deg :: Number -> Angle Deg
 deg i = Angle $ (value i <> fromString "deg")
 
+-- | Angle in radians.
 rad :: Number -> Angle Rad
 rad i = Angle $ (value i <> fromString "rad")


### PR DESCRIPTION
Ported [from Clay](https://github.com/sebastiaanvisser/clay/blob/03f90289eba89fa72cfc81b1f9685f699c954fd9/src/Clay/Size.hs#L123).

Resolves #79 