### PR TITLE
Add text-overflow CSS property

### DIFF
--- a/src/CSS.purs
+++ b/src/CSS.purs
@@ -22,6 +22,8 @@ import CSS.String (class IsString, fromString) as X
 import CSS.Stylesheet (App(..), CSS, Feature(..), Keyframes(..), MediaQuery(..), MediaType(..), NotOrOnly(..), Rule(..), StyleM(..), fontFace, importUrl, key, keyframes, keyframesFromTo, prefixed, query, rule, runS, select, (?)) as X
 import CSS.Text (TextDecoration(..), blink, letterSpacing, lineThrough, noneTextDecoration, overline, textDecoration, underline) as X
 import CSS.Text.Whitespace (TextWhitespace, textWhitespace, whitespaceNoWrap, whitespaceNormal, whitespacePre, whitespacePreLine, whitespacePreWrap) as X
+import CSS.Text.Transform (TextTransform, textTransform) as X
+import CSS.Text.Overflow (TextOverflow, textOverflow) as X
 import CSS.Time (Time(..), ms, sec) as X
 import CSS.Transform (TransformOrigin(..), TransformOriginOffset(..), Transformation(..), offset, offsetBottom, offsetCenter, offsetLeft, offsetRight, offsetTop, rotate, transform, transformOrigin, transforms, translate) as X
 import CSS.Transition (TimingFunction(..), easeOut, linear) as X

--- a/src/CSS/Text/Overflow.purs
+++ b/src/CSS/Text/Overflow.purs
@@ -1,0 +1,39 @@
+module CSS.Text.Overflow
+  ( TextOverflow
+  , textOverflow
+  , clip
+  , ellipsis
+  , custom
+  ) where
+
+import CSS.Property (class Val, quote)
+import CSS.String (fromString)
+import CSS.Stylesheet (CSS, key)
+import Data.Eq (class Eq)
+import Data.Function (($))
+import Data.Ord (class Ord)
+
+data TextOverflow
+  = Clip
+  | Ellipsis
+  | Custom String
+
+derive instance eqTextOverflow :: Eq TextOverflow
+derive instance ordTextOverflow :: Ord TextOverflow
+
+instance valTextOverflow :: Val TextOverflow where
+  value Clip = fromString "clip"
+  value Ellipsis = fromString "ellipsis"
+  value (Custom v) = fromString $ quote v
+
+textOverflow :: TextOverflow -> CSS
+textOverflow = key $ fromString "text-overflow"
+
+clip :: TextOverflow
+clip = Clip
+
+ellipsis :: TextOverflow
+ellipsis = Ellipsis
+
+custom :: String -> TextOverflow
+custom = Custom

--- a/src/CSS/Text/Transform.purs
+++ b/src/CSS/Text/Transform.purs
@@ -27,14 +27,14 @@ derive instance eqTextTransform :: Eq TextTransform
 derive instance ordTextTransform :: Ord TextTransform
 
 instance valTextTransform :: Val TextTransform where
-  value (Uppercase)  = fromString "uppercase"
-  value (Lowercase)  = fromString "lowercase"
-  value (Capitalize) = fromString "capitalize"
-  value (None)       = fromString "none"
-  value (Initial)    = fromString "initial"
-  value (Inherit)    = fromString "inherit"
+  value Uppercase  = fromString "uppercase"
+  value Lowercase  = fromString "lowercase"
+  value Capitalize = fromString "capitalize"
+  value None       = fromString "none"
+  value Initial    = fromString "initial"
+  value Inherit    = fromString "inherit"
 
-instance showTextTransform :: Show (TextTransform) where
+instance showTextTransform :: Show TextTransform where
   show Uppercase = "Uppercase"
   show Lowercase = "Lowercase"
   show Capitalize = "Capitalize"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,8 +4,9 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Exception (error, throwException)
-import CSS (Rendered, Path(..), Predicate(..), Refinement(..), Selector(..), FontFaceSrc(..), FontFaceFormat(..), renderedSheet, renderedInline, fromString, selector, block, display, render, borderBox, boxSizing, contentBox, blue, color, body, a, p, px, dashed, border, inlineBlock, red, (?), (##), (|>), (**), hover, fontFaceSrc, fontStyle, deg, zIndex)
+import CSS (Rendered, Path(..), Predicate(..), Refinement(..), Selector(..), FontFaceSrc(..), FontFaceFormat(..), renderedSheet, renderedInline, fromString, selector, block, display, render, borderBox, boxSizing, contentBox, blue, color, body, a, p, px, dashed, border, inlineBlock, red, (?), (##), (|>), (**), hover, fontFaceSrc, fontStyle, deg, zIndex, textOverflow)
 import CSS.FontStyle as FontStyle
+import CSS.Text.Overflow as TextOverflow
 import Data.Maybe (Maybe(..))
 import Data.NonEmpty (singleton)
 
@@ -71,6 +72,14 @@ exampleFontStyle3 :: Rendered
 exampleFontStyle3 = render do
   fontStyle $ FontStyle.obliqueAngle (deg 45.0)
 
+exampleTextOverflow1 :: Rendered
+exampleTextOverflow1 = render do
+  textOverflow TextOverflow.ellipsis
+
+exampleTextOverflow2 :: Rendered
+exampleTextOverflow2 = render do
+  textOverflow $ TextOverflow.custom "foobar"
+
 nestedNodes :: Rendered
 nestedNodes = render do
   fromString "#parent" ? do
@@ -114,3 +123,6 @@ main = do
   renderedInline exampleFontStyle1 `assertEqual` Just "font-style: italic"
   renderedInline exampleFontStyle2 `assertEqual` Just "font-style: oblique"
   renderedInline exampleFontStyle3 `assertEqual` Just "font-style: oblique 45.0deg"
+
+  renderedInline exampleTextOverflow1 `assertEqual` Just "text-overflow: ellipsis"
+  renderedInline exampleTextOverflow2 `assertEqual` Just "text-overflow: \"foobar\""


### PR DESCRIPTION
This PR adds only basic support for `text-overflow` (I believe only `fade` is missing), but should cover most use-cases of this property.

Resolves #96 